### PR TITLE
fix: avoid sending query params for AssetPairs endpoint

### DIFF
--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/market/params/AssetPairParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/market/params/AssetPairParams.java
@@ -1,5 +1,8 @@
 package dev.andstuff.kraken.api.endpoint.market.params;
 
+import static dev.andstuff.kraken.api.endpoint.pub.QueryParams.putIfNonNull;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -14,9 +17,10 @@ public class AssetPairParams implements QueryParams {
     private final Info info;
 
     public Map<String, String> toMap() {
-        return Map.of(
-                "pair", String.join(",", pairs),
-                "info", info.getValue());
+        HashMap<String, String> params = new HashMap<>();
+        putIfNonNull(params, "pair", pairs, v -> String.join(",", v));
+        putIfNonNull(params, "info", info, Info::getValue);
+        return params;
     }
 
     @Getter

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/market/response/AssetPair.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/market/response/AssetPair.java
@@ -28,8 +28,8 @@ public record AssetPair(@JsonProperty("altname") String alternateName,
                         @JsonProperty("costmin") BigDecimal minimumOrderCost,
                         @JsonProperty("tick_size") BigDecimal tickSize,
                         @JsonProperty("status") Status status,
-                        @JsonProperty("long_position_limit") int maxLongPositionSize,
-                        @JsonProperty("short_position_limit") int maxShortPositionSize) {
+                        @JsonProperty("long_position_limit") long maxLongPositionSize,
+                        @JsonProperty("short_position_limit") long maxShortPositionSize) {
 
     @JsonFormat(shape = JsonFormat.Shape.ARRAY)
     public record FeeSchedule(BigDecimal volume, BigDecimal percentage) {}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/pub/QueryParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/pub/QueryParams.java
@@ -1,10 +1,17 @@
 package dev.andstuff.kraken.api.endpoint.pub;
 
 import java.util.Map;
+import java.util.function.Function;
 
 public interface QueryParams {
 
     QueryParams EMPTY = Map::of;
 
     Map<String, String> toMap();
+
+    static <T> void putIfNonNull(Map<String, String> map, String key, T value, Function<T, String> apply) {
+        if (value != null) {
+            map.put(key, apply.apply(value));
+        }
+    }
 }


### PR DESCRIPTION
* Avoid sending query params for AssetPairs endpoint.
* Change type of DTO for position limits from int to long.