### PR TITLE
feat: type the Subaccounts endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Java 25 with Temurin is required (configured via `maven-compiler-plugin` with `<
 
 `KrakenAPI` is the entry point: typed methods for implemented endpoints, generic `query()` methods taking a `Public`/`Private` enum value and returning a `JsonNode`, and raw `queryPublic()`/`queryPrivate()` taking a path string.
 
-Every endpoint extends `Endpoint<T>`, either `PublicEndpoint<T>` (GET on `/0/public/{path}`, parameters from `QueryParams`) or `PrivateEndpoint<T>` (POST on `/0/private/{path}`, parameters from `PostParams`, signed with a nonce-based HMAC). Concrete endpoints live in a domain package under `endpoint/` — `market/` for public market data, `account/` for private account data — and follow `{Name}Endpoint`, `params/{Name}Params`, `response/{ResponseType}`.
+Every endpoint extends `Endpoint<T>`, either `PublicEndpoint<T>` (GET on `/0/public/{path}`, parameters from `QueryParams`) or `PrivateEndpoint<T>` (POST on `/0/private/{path}`, parameters from `PostParams`, signed with a nonce-based HMAC). Concrete endpoints live in a domain package under `endpoint/` — `market/` for public market data, `account/` for private account data, `subaccount/` for subaccount management — and follow `{Name}Endpoint`, `params/{Name}Params`, `response/{ResponseType}`.
 
 `KrakenRestRequester` performs the HTTP calls and can be swapped for another HTTP client. Responses are unwrapped from the Kraken `{error, result}` envelope by `KrakenResponse<T>`; ZIP responses (report exports) go through `Endpoint.processZipResponse()`.
 

--- a/library/src/main/java/dev/andstuff/kraken/api/KrakenAPI.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/KrakenAPI.java
@@ -38,6 +38,11 @@ import dev.andstuff.kraken.api.endpoint.market.response.Ticker;
 import dev.andstuff.kraken.api.endpoint.priv.JsonPrivateEndpoint;
 import dev.andstuff.kraken.api.endpoint.priv.PrivateEndpoint;
 import dev.andstuff.kraken.api.endpoint.pub.JsonPublicEndpoint;
+import dev.andstuff.kraken.api.endpoint.subaccount.AccountTransferEndpoint;
+import dev.andstuff.kraken.api.endpoint.subaccount.CreateSubaccountEndpoint;
+import dev.andstuff.kraken.api.endpoint.subaccount.params.AccountTransferParams;
+import dev.andstuff.kraken.api.endpoint.subaccount.params.CreateSubaccountParams;
+import dev.andstuff.kraken.api.endpoint.subaccount.response.AccountTransfer;
 import dev.andstuff.kraken.api.rest.DefaultKrakenRestRequester;
 import dev.andstuff.kraken.api.rest.EpochBasedNonceGenerator;
 import dev.andstuff.kraken.api.rest.KrakenCredentials;
@@ -293,6 +298,28 @@ public class KrakenAPI {
      */
     public boolean cancelReport(String id) {
         return executePrivate(new RemoveReportEndpoint(RemoveReportParams.of(id, RemovalType.CANCEL))).wasCanceled();
+    }
+
+    /**
+     * Queries the private {@code CreateSubaccount} endpoint, creating a trading subaccount. It must be called with an API key of the master account, having the withdraw funds permission.
+     *
+     * @param params the username and email address of the subaccount
+     * @return whether the subaccount was created
+     * @throws KrakenException if Kraken returns an error
+     */
+    public boolean createSubaccount(CreateSubaccountParams params) {
+        return executePrivate(new CreateSubaccountEndpoint(params));
+    }
+
+    /**
+     * Queries the private {@code AccountTransfer} endpoint, transferring funds between the master account and its subaccounts. It must be called with an API key of the master account, having the withdraw funds permission.
+     *
+     * @param params the asset, amount and accounts of the transfer
+     * @return the identifier and status of the transfer
+     * @throws KrakenException if Kraken returns an error
+     */
+    public AccountTransfer accountTransfer(AccountTransferParams params) {
+        return executePrivate(new AccountTransferEndpoint(params));
     }
 
     private <T> T executePrivate(PrivateEndpoint<T> endpoint) {

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/AccountTransferEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/AccountTransferEndpoint.java
@@ -1,0 +1,22 @@
+package dev.andstuff.kraken.api.endpoint.subaccount;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.priv.PrivateEndpoint;
+import dev.andstuff.kraken.api.endpoint.subaccount.params.AccountTransferParams;
+import dev.andstuff.kraken.api.endpoint.subaccount.response.AccountTransfer;
+
+/**
+ * The private {@code AccountTransfer} endpoint, transferring funds between the master account and its subaccounts. It must be called with an API key of the master account.
+ */
+public class AccountTransferEndpoint extends PrivateEndpoint<AccountTransfer> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the asset, amount and accounts of the transfer
+     */
+    public AccountTransferEndpoint(AccountTransferParams params) {
+        super("AccountTransfer", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/CreateSubaccountEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/CreateSubaccountEndpoint.java
@@ -1,0 +1,21 @@
+package dev.andstuff.kraken.api.endpoint.subaccount;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.priv.PrivateEndpoint;
+import dev.andstuff.kraken.api.endpoint.subaccount.params.CreateSubaccountParams;
+
+/**
+ * The private {@code CreateSubaccount} endpoint, creating a trading subaccount. It must be called with an API key of the master account.
+ */
+public class CreateSubaccountEndpoint extends PrivateEndpoint<Boolean> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the username and email address of the subaccount
+     */
+    public CreateSubaccountEndpoint(CreateSubaccountParams params) {
+        super("CreateSubaccount", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/params/AccountTransferParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/params/AccountTransferParams.java
@@ -1,0 +1,44 @@
+package dev.andstuff.kraken.api.endpoint.subaccount.params;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.andstuff.kraken.api.endpoint.priv.PostParams;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * The parameters of the {@code AccountTransfer} endpoint. Source and destination are public account identifiers, e.g. {@code ABCD 1234 EFGH 5678}, and the asset class defaults to {@link AssetClass#CURRENCY}.
+ */
+@Getter
+@Builder(toBuilder = true)
+public class AccountTransferParams extends PostParams {
+
+    @NonNull
+    private final String asset;
+
+    @Builder.Default
+    private final AssetClass assetClass = AssetClass.CURRENCY;
+
+    @NonNull
+    private final BigDecimal amount;
+
+    @NonNull
+    private final String from;
+
+    @NonNull
+    private final String to;
+
+    @Override
+    protected Map<String, String> params() {
+        Map<String, String> params = new HashMap<>();
+        params.put("asset", asset);
+        putIfNonNull(params, "asset_class", assetClass, e -> e.toString().toLowerCase());
+        params.put("amount", amount.toPlainString());
+        params.put("from", from);
+        params.put("to", to);
+        return params;
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/params/AssetClass.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/params/AssetClass.java
@@ -1,0 +1,8 @@
+package dev.andstuff.kraken.api.endpoint.subaccount.params;
+
+/**
+ * The class of the asset being transferred by the {@code AccountTransfer} endpoint.
+ */
+public enum AssetClass {
+    CURRENCY, TOKENIZED_ASSET
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/params/CreateSubaccountParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/params/CreateSubaccountParams.java
@@ -1,0 +1,31 @@
+package dev.andstuff.kraken.api.endpoint.subaccount.params;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.andstuff.kraken.api.endpoint.priv.PostParams;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The parameters of the {@code CreateSubaccount} endpoint.
+ */
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class CreateSubaccountParams extends PostParams {
+
+    @NonNull
+    private final String username;
+
+    @NonNull
+    private final String email;
+
+    @Override
+    protected Map<String, String> params() {
+        Map<String, String> params = new HashMap<>();
+        params.put("username", username);
+        params.put("email", email);
+        return params;
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/response/AccountTransfer.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/subaccount/response/AccountTransfer.java
@@ -1,0 +1,25 @@
+package dev.andstuff.kraken.api.endpoint.subaccount.response;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The response of the {@code AccountTransfer} endpoint.
+ *
+ * @param transferId the identifier of the transfer
+ * @param status the status of the transfer
+ */
+public record AccountTransfer(@JsonProperty("transfer_id") String transferId,
+                              Status status) {
+
+    /**
+     * The status of a transfer between accounts.
+     */
+    public enum Status {
+        PENDING,
+        COMPLETE,
+
+        @JsonEnumDefaultValue
+        UNKNOWN
+    }
+}


### PR DESCRIPTION
Types the two Subaccounts endpoints of the Kraken Spot REST API, part of the coverage effort tracked in #82.

## What's added

- `endpoint/subaccount/` — new domain package, alongside `market/` and `account/`
- `CreateSubaccountEndpoint` → `PrivateEndpoint<Boolean>`, params `CreateSubaccountParams.of(username, email)`
- `AccountTransferEndpoint` → `PrivateEndpoint<AccountTransfer>`, params `AccountTransferParams` (builder: `asset`, `assetClass`, `amount`, `from`, `to`)
- `AccountTransfer` response record — `transferId` (`transfer_id`) and a `Status` enum (`PENDING`, `COMPLETE`, `UNKNOWN` as `@JsonEnumDefaultValue`)
- `AssetClass` params enum — `CURRENCY`, `TOKENIZED_ASSET`, lowercased on the wire, defaulting to `CURRENCY`
- `KrakenAPI.createSubaccount(params)` and `KrakenAPI.accountTransfer(params)`

## Notes

Amounts are typed as `BigDecimal` and serialized with `toPlainString()` so no scientific notation reaches Kraken. Both endpoints must be called with an API key of the master account holding the withdraw funds permission — stated in the Javadoc of the endpoint and of the `KrakenAPI` method.

`Private.CREATE_SUB_ACCOUNT` and `Private.ACCOUNT_TRANSFER` already existed, so the enum is unchanged. `AGENTS.md` gains `subaccount/` in the domain package list.

Verified against Kraken's OpenAPI spec (`https://docs.kraken.com/openapi/spot-rest.yaml`). `mvn clean package` passes; `javadoc:jar` produces only the `-missing` warnings the project already tolerates on obvious enum constants.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
