### PR TITLE
feat: type the Transparency endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Java 25 with Temurin is required (configured via `maven-compiler-plugin` with `<
 
 `KrakenAPI` is the entry point: typed methods for implemented endpoints, generic `query()` methods taking a `Public`/`Private` enum value and returning a `JsonNode`, and raw `queryPublic()`/`queryPrivate()` taking a path string.
 
-Every endpoint extends `Endpoint<T>`, either `PublicEndpoint<T>` (GET on `/0/public/{path}`, parameters from `QueryParams`) or `PrivateEndpoint<T>` (POST on `/0/private/{path}`, parameters from `PostParams`, signed with a nonce-based HMAC). Concrete endpoints live in a domain package under `endpoint/` — `market/` for public market data, `account/` for private account data, `subaccount/` for subaccount management — and follow `{Name}Endpoint`, `params/{Name}Params`, `response/{ResponseType}`.
+Every endpoint extends `Endpoint<T>`, either `PublicEndpoint<T>` (GET on `/0/public/{path}`, parameters from `QueryParams`) or `PrivateEndpoint<T>` (POST on `/0/private/{path}`, parameters from `PostParams`, signed with a nonce-based HMAC). Concrete endpoints live in a domain package under `endpoint/` — `market/` for public market data, `account/` for private account data, `subaccount/` for subaccount management, `transparency/` for public pre- and post-trade data — and follow `{Name}Endpoint`, `params/{Name}Params`, `response/{ResponseType}`.
 
 `KrakenRestRequester` performs the HTTP calls and can be swapped for another HTTP client. Responses are unwrapped from the Kraken `{error, result}` envelope by `KrakenResponse<T>`; ZIP responses (report exports) go through `Endpoint.processZipResponse()`.
 

--- a/library/src/main/java/dev/andstuff/kraken/api/KrakenAPI.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/KrakenAPI.java
@@ -43,6 +43,12 @@ import dev.andstuff.kraken.api.endpoint.subaccount.CreateSubaccountEndpoint;
 import dev.andstuff.kraken.api.endpoint.subaccount.params.AccountTransferParams;
 import dev.andstuff.kraken.api.endpoint.subaccount.params.CreateSubaccountParams;
 import dev.andstuff.kraken.api.endpoint.subaccount.response.AccountTransfer;
+import dev.andstuff.kraken.api.endpoint.transparency.PostTradeEndpoint;
+import dev.andstuff.kraken.api.endpoint.transparency.PreTradeEndpoint;
+import dev.andstuff.kraken.api.endpoint.transparency.params.PostTradeParams;
+import dev.andstuff.kraken.api.endpoint.transparency.params.PreTradeParams;
+import dev.andstuff.kraken.api.endpoint.transparency.response.PostTrade;
+import dev.andstuff.kraken.api.endpoint.transparency.response.PreTrade;
 import dev.andstuff.kraken.api.rest.DefaultKrakenRestRequester;
 import dev.andstuff.kraken.api.rest.EpochBasedNonceGenerator;
 import dev.andstuff.kraken.api.rest.KrakenCredentials;
@@ -219,6 +225,39 @@ public class KrakenAPI {
      */
     public Map<String, Ticker> ticker(List<String> pairs) {
         return restRequester.execute(new TickerEndpoint(pairs));
+    }
+
+    /**
+     * Queries the {@code PreTrade} endpoint, returning the aggregated order book of a currency pair, with at most ten price levels on each side.
+     *
+     * @param symbol the currency pair, in the {@code BASE/QUOTE} display format, e.g. {@code BTC/USD}
+     * @return the aggregated order book
+     * @throws KrakenException if Kraken returns an error
+     */
+    public PreTrade preTrade(String symbol) {
+        return restRequester.execute(new PreTradeEndpoint(PreTradeParams.of(symbol)));
+    }
+
+    /**
+     * Queries the {@code PostTrade} endpoint, returning the last 1000 trades executed on a currency pair.
+     *
+     * @param symbol the currency pair, in the {@code BASE/QUOTE} display format, e.g. {@code BTC/USD}
+     * @return the executed trades
+     * @throws KrakenException if Kraken returns an error
+     */
+    public PostTrade postTrade(String symbol) {
+        return restRequester.execute(new PostTradeEndpoint(PostTradeParams.builder().symbol(symbol).build()));
+    }
+
+    /**
+     * Queries the {@code PostTrade} endpoint, returning the trades executed on a currency pair over the given period. Trades are returned in ascending time order and at most 1000 at a time: {@link PostTrade#lastTimestamp()} gives the timestamp to use as the next {@code fromTimestamp}.
+     *
+     * @param params the currency pair and the period and count restricting the trades returned
+     * @return the executed trades
+     * @throws KrakenException if Kraken returns an error
+     */
+    public PostTrade postTrade(PostTradeParams params) {
+        return restRequester.execute(new PostTradeEndpoint(params));
     }
 
     /* Implemented private endpoints */

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/PostTradeEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/PostTradeEndpoint.java
@@ -1,0 +1,22 @@
+package dev.andstuff.kraken.api.endpoint.transparency;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.pub.PublicEndpoint;
+import dev.andstuff.kraken.api.endpoint.transparency.params.PostTradeParams;
+import dev.andstuff.kraken.api.endpoint.transparency.response.PostTrade;
+
+/**
+ * The public {@code PostTrade} endpoint, returning the trades executed on the spot exchange for a currency pair.
+ */
+public class PostTradeEndpoint extends PublicEndpoint<PostTrade> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the currency pair and the period and count restricting the trades returned
+     */
+    public PostTradeEndpoint(PostTradeParams params) {
+        super("PostTrade", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/PreTradeEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/PreTradeEndpoint.java
@@ -1,0 +1,22 @@
+package dev.andstuff.kraken.api.endpoint.transparency;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.pub.PublicEndpoint;
+import dev.andstuff.kraken.api.endpoint.transparency.params.PreTradeParams;
+import dev.andstuff.kraken.api.endpoint.transparency.response.PreTrade;
+
+/**
+ * The public {@code PreTrade} endpoint, returning the aggregated order book of a currency pair, with at most ten price levels on each side.
+ */
+public class PreTradeEndpoint extends PublicEndpoint<PreTrade> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the symbol of the currency pair
+     */
+    public PreTradeEndpoint(PreTradeParams params) {
+        super("PreTrade", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/params/PostTradeParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/params/PostTradeParams.java
@@ -1,0 +1,37 @@
+package dev.andstuff.kraken.api.endpoint.transparency.params;
+
+import static dev.andstuff.kraken.api.endpoint.pub.QueryParams.putIfNonNull;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.andstuff.kraken.api.endpoint.pub.QueryParams;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * The parameters of the {@code PostTrade} endpoint. The symbol is required, in the {@code BASE/QUOTE} display format, and the trades can be further restricted to a period and to a maximum count.
+ */
+@Getter
+@Builder(toBuilder = true)
+public class PostTradeParams implements QueryParams {
+
+    @NonNull
+    private final String symbol;
+
+    private final Instant fromTimestamp;
+    private final Instant toTimestamp;
+    private final Integer count;
+
+    @Override
+    public Map<String, String> toMap() {
+        Map<String, String> params = new HashMap<>();
+        params.put("symbol", symbol);
+        putIfNonNull(params, "from_ts", fromTimestamp, Instant::toString);
+        putIfNonNull(params, "to_ts", toTimestamp, Instant::toString);
+        putIfNonNull(params, "count", count, String::valueOf);
+        return params;
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/params/PreTradeParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/params/PreTradeParams.java
@@ -1,0 +1,24 @@
+package dev.andstuff.kraken.api.endpoint.transparency.params;
+
+import java.util.Map;
+
+import dev.andstuff.kraken.api.endpoint.pub.QueryParams;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The parameters of the {@code PreTrade} endpoint. Kraken expects a single symbol, in the {@code BASE/QUOTE} display format.
+ */
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class PreTradeParams implements QueryParams {
+
+    @NonNull
+    private final String symbol;
+
+    @Override
+    public Map<String, String> toMap() {
+        return Map.of("symbol", symbol);
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/response/Notation.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/response/Notation.java
@@ -1,0 +1,15 @@
+package dev.andstuff.kraken.api.endpoint.transparency.response;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+/**
+ * How a quantity or a price is expressed in the transparency data.
+ */
+public enum Notation {
+    UNIT,
+    NOML,
+    MONE,
+
+    @JsonEnumDefaultValue
+    UNKNOWN
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/response/PostTrade.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/response/PostTrade.java
@@ -1,0 +1,58 @@
+package dev.andstuff.kraken.api.endpoint.transparency.response;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The response of the {@code PostTrade} endpoint, i.e. a batch of executed trades.
+ *
+ * @param lastTimestamp the time of the latest trade of the batch, to be used as the next {@code fromTimestamp} to page through trades
+ * @param count the number of trades returned
+ * @param trades the trades, in ascending time order
+ */
+public record PostTrade(@JsonProperty("last_ts") Instant lastTimestamp,
+                        int count,
+                        List<Trade> trades) {
+
+    /**
+     * A single executed trade.
+     *
+     * @param tradeId the Kraken identifier of the trade
+     * @param price the trade price, excluding fees and commissions
+     * @param quantity the unconsolidated trade quantity from execution
+     * @param symbol the symbol of the currency pair, e.g. {@code BTC/USD}
+     * @param description the full description of the currency pair, e.g. {@code Bitcoin / US Dollar}
+     * @param baseAsset the currency code of the base asset
+     * @param baseNotation how the quantity is expressed
+     * @param baseDtiCode the Digital Token Identifier code of the base asset, empty if it has none
+     * @param baseDtiShortName the Digital Token Identifier short name of the base asset, empty if it has none
+     * @param quoteAsset the currency the price is expressed in
+     * @param quoteNotation how the price is expressed
+     * @param quoteDtiCode the Digital Token Identifier code of the quote asset, empty if it has none
+     * @param quoteDtiShortName the Digital Token Identifier short name of the quote asset, empty if it has none
+     * @param tradeVenue the Market Identifier Code of the trading platform the trade was executed on
+     * @param tradeTimestamp the time the trade was matched in the engine
+     * @param publicationVenue the Market Identifier Code of the trading platform the trade was published on
+     * @param publicationTimestamp the time the trade was published to the market data streams
+     */
+    public record Trade(@JsonProperty("trade_id") String tradeId,
+                        BigDecimal price,
+                        BigDecimal quantity,
+                        String symbol,
+                        String description,
+                        @JsonProperty("base_asset") String baseAsset,
+                        @JsonProperty("base_notation") Notation baseNotation,
+                        @JsonProperty("base_dti_code") String baseDtiCode,
+                        @JsonProperty("base_dti_short_name") String baseDtiShortName,
+                        @JsonProperty("quote_asset") String quoteAsset,
+                        @JsonProperty("quote_notation") Notation quoteNotation,
+                        @JsonProperty("quote_dti_code") String quoteDtiCode,
+                        @JsonProperty("quote_dti_short_name") String quoteDtiShortName,
+                        @JsonProperty("trade_venue") String tradeVenue,
+                        @JsonProperty("trade_ts") Instant tradeTimestamp,
+                        @JsonProperty("publication_venue") String publicationVenue,
+                        @JsonProperty("publication_ts") Instant publicationTimestamp) {}
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/response/PreTrade.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/transparency/response/PreTrade.java
@@ -1,0 +1,80 @@
+package dev.andstuff.kraken.api.endpoint.transparency.response;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The response of the {@code PreTrade} endpoint, i.e. the aggregated order book of a single currency pair, with at most ten price levels on each side.
+ *
+ * @param symbol the symbol of the currency pair, e.g. {@code BTC/USD}
+ * @param description the full description of the currency pair, e.g. {@code Bitcoin / US Dollar}
+ * @param baseAsset the currency code of the base asset
+ * @param baseNotation how the quantity is expressed
+ * @param baseDtiCode the Digital Token Identifier code of the base asset, empty if it has none
+ * @param baseDtiShortName the Digital Token Identifier short name of the base asset, empty if it has none
+ * @param quoteAsset the currency the price is expressed in
+ * @param quoteNotation how the price is expressed
+ * @param quoteDtiCode the Digital Token Identifier code of the quote asset, empty if it has none
+ * @param quoteDtiShortName the Digital Token Identifier short name of the quote asset, empty if it has none
+ * @param venue the Market Identifier Code of the trading platform the orders were submitted on
+ * @param system the type of order system the price levels come from
+ * @param bids the bid price levels, in decreasing price order
+ * @param asks the ask price levels, in increasing price order
+ */
+public record PreTrade(String symbol,
+                       String description,
+                       @JsonProperty("base_asset") String baseAsset,
+                       @JsonProperty("base_notation") Notation baseNotation,
+                       @JsonProperty("base_dti_code") String baseDtiCode,
+                       @JsonProperty("base_dti_short_name") String baseDtiShortName,
+                       @JsonProperty("quote_asset") String quoteAsset,
+                       @JsonProperty("quote_notation") Notation quoteNotation,
+                       @JsonProperty("quote_dti_code") String quoteDtiCode,
+                       @JsonProperty("quote_dti_short_name") String quoteDtiShortName,
+                       String venue,
+                       OrderSystem system,
+                       List<PriceLevel> bids,
+                       List<PriceLevel> asks) {
+
+    /**
+     * A single price level of the aggregated order book.
+     *
+     * @param side whether the price level is a bid or an ask
+     * @param price the price of the level
+     * @param quantity the aggregated quantity at the price level
+     * @param count the number of orders in the price level
+     * @param submissionTimestamp the time the order at this price level was submitted
+     * @param publicationTimestamp the time the price level was last updated and published
+     */
+    public record PriceLevel(Side side,
+                             BigDecimal price,
+                             @JsonProperty("qty") BigDecimal quantity,
+                             int count,
+                             @JsonProperty("submission_ts") Instant submissionTimestamp,
+                             @JsonProperty("publication_ts") Instant publicationTimestamp) {}
+
+    /**
+     * The side of a price level.
+     */
+    public enum Side {
+        BUY,
+        SELL,
+
+        @JsonEnumDefaultValue
+        UNKNOWN
+    }
+
+    /**
+     * The type of order system the price levels come from.
+     */
+    public enum OrderSystem {
+        CLOB,
+
+        @JsonEnumDefaultValue
+        UNKNOWN
+    }
+}


### PR DESCRIPTION
Types the two Transparency endpoints of the Kraken Spot REST API, part of the coverage effort tracked in #82.

## What's added

- `endpoint/transparency/` — new domain package, alongside `market/`, `account/` and `subaccount/`
- `PreTradeEndpoint` → `PublicEndpoint<PreTrade>`, params `PreTradeParams.of(symbol)`
- `PostTradeEndpoint` → `PublicEndpoint<PostTrade>`, params `PostTradeParams` (builder: `symbol`, `fromTimestamp`, `toTimestamp`, `count`)
- `PreTrade` response record — pair metadata, DTI codes, `bids`/`asks` as `PriceLevel` records, with `Side` and `OrderSystem` enums
- `PostTrade` response record — `lastTimestamp`, `count` and a list of `Trade` records
- `Notation` enum shared by both responses — `UNIT`, `NOML`, `MONE`
- `KrakenAPI.preTrade(symbol)`, `KrakenAPI.postTrade(symbol)` and `KrakenAPI.postTrade(params)`

## Notes

Both endpoints are public and need no credentials. `symbol` is required on both: the spec marks it optional on `PostTrade`, but the live API answers `EGeneral:Invalid arguments` without it, so `PostTradeParams` takes it as `@NonNull`. `PreTrade` accepts a single pair only — a comma separated list answers `EQuery:Unknown asset pair` — so the parameter is a plain `String` rather than a `List`.

Timestamps are `Instant`, serialized as ISO 8601 for `from_ts`/`to_ts` and parsed back with nanosecond precision. Prices and quantities are `BigDecimal`. MIC codes (`venue`, `trade_venue`, `publication_venue`) stay `String` since the ISO 10383 registry is open-ended, while the closed sets (`base_notation`, `quote_notation`, `side`, `system`) are enums with a `@JsonEnumDefaultValue UNKNOWN` constant.

Two fields returned by the live API are missing from the spec's `post-trade` schema and are mapped anyway: `base_dti_code` / `base_dti_short_name` and `quote_dti_code` / `quote_dti_short_name` on each trade.

`Public.PRE_TRADE` and `Public.POST_TRADE` already existed, so the enum is unchanged. `AGENTS.md` gains `transparency/` in the domain package list.

## Verification

Checked against Kraken's OpenAPI spec (`https://docs.kraken.com/openapi/spot-rest.yaml`) and against the live `api.kraken.com` responses. `mvn clean package` passes and `javadoc:jar` produces no new warnings. A smoke run against the real API deserialized every field of both responses: ten bids and ten asks on `BTC/USD`, 1000 trades in a default `PostTrade` call, and paging with `toTimestamp` back to the 2013 trades.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
