### PR TITLE
refactor: route the Transparency methods through the public query method

### DIFF
--- a/library/src/main/java/dev/andstuff/kraken/api/KrakenAPI.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/KrakenAPI.java
@@ -237,7 +237,7 @@ public class KrakenAPI {
      * @throws KrakenException if Kraken returns an error
      */
     public PreTrade preTrade(String symbol) {
-        return restRequester.execute(new PreTradeEndpoint(PreTradeParams.of(symbol)));
+        return query(new PreTradeEndpoint(PreTradeParams.of(symbol)));
     }
 
     /**
@@ -248,7 +248,7 @@ public class KrakenAPI {
      * @throws KrakenException if Kraken returns an error
      */
     public PostTrade postTrade(String symbol) {
-        return restRequester.execute(new PostTradeEndpoint(PostTradeParams.builder().symbol(symbol).build()));
+        return query(new PostTradeEndpoint(PostTradeParams.builder().symbol(symbol).build()));
     }
 
     /**
@@ -259,7 +259,7 @@ public class KrakenAPI {
      * @throws KrakenException if Kraken returns an error
      */
     public PostTrade postTrade(PostTradeParams params) {
-        return restRequester.execute(new PostTradeEndpoint(params));
+        return query(new PostTradeEndpoint(params));
     }
 
     /* Implemented private endpoints */


### PR DESCRIPTION
Converts the three `restRequester.execute(new …)` call sites left in `KrakenAPI` — `preTrade(symbol)`, `postTrade(symbol)` and `postTrade(params)` — to `query(new …)`.

#92 collapsed every call site of the class onto `query(PublicEndpoint<T>)` / `query(PrivateEndpoint<T>)`, but its branch was cut before #90 added the Transparency endpoints, so those three survived the merge and are the only methods left reaching for the requester directly.

No behaviour change: `query(PublicEndpoint<T>)` is a one-line delegation to the very call these methods were making. With this, `restRequester` is back to exactly two readers and the class has one path to the requester per endpoint kind.

## Verification

`mvn clean package` passes. `preTrade("BTC/USD")` and `postTrade("BTC/USD")` checked against the live public API with a throwaway class (not committed), both returning the same populated records as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
