### PR TITLE
feat: type the Earn endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Java 25 with Temurin is required (configured via `maven-compiler-plugin` with `<
 
 `KrakenAPI` is the entry point: typed methods for implemented endpoints, generic `query()` methods taking a `Public`/`Private` enum value and returning a `JsonNode`, and raw `queryPublic()`/`queryPrivate()` taking a path string.
 
-Every endpoint extends `Endpoint<T>`, either `PublicEndpoint<T>` (GET on `/0/public/{path}`, parameters from `QueryParams`) or `PrivateEndpoint<T>` (POST on `/0/private/{path}`, parameters from `PostParams`, signed with a nonce-based HMAC). Concrete endpoints live in a domain package under `endpoint/` — `market/` for public market data, `account/` for private account data, `subaccount/` for subaccount management, `transparency/` for public pre- and post-trade data — and follow `{Name}Endpoint`, `params/{Name}Params`, `response/{ResponseType}`.
+Every endpoint extends `Endpoint<T>`, either `PublicEndpoint<T>` (GET on `/0/public/{path}`, parameters from `QueryParams`) or `PrivateEndpoint<T>` (POST on `/0/private/{path}`, parameters from `PostParams`, signed with a nonce-based HMAC). Concrete endpoints live in a domain package under `endpoint/` — `market/` for public market data, `account/` for private account data, `subaccount/` for subaccount management, `transparency/` for public pre- and post-trade data, `earn/` for earn strategies and allocations — and follow `{Name}Endpoint`, `params/{Name}Params`, `response/{ResponseType}`.
 
 `KrakenRestRequester` performs the HTTP calls and can be swapped for another HTTP client. Responses are unwrapped from the Kraken `{error, result}` envelope by `KrakenResponse<T>`; ZIP responses (report exports) go through `Endpoint.processZipResponse()`.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ This example will generate the `rewards-summary.csv` file, showing how much cryp
 
 ![staking-reward-summary](images/staking-rewards-example.png)
 
+### Earn Overview
+
+This example prints where the assets of your account are earning — which strategy holds them, its lock type and estimated APR, what it has paid so far — and which spot balances could still be allocated to a strategy that accepts them, best estimated APR first. Read-only API key permissions are enough, the example never allocates or deallocates anything.
+
+```sh
+mvn -pl examples exec:java -Dexec.mainClass=dev.andstuff.kraken.example.EarnOverviewExample
+```
+
 ### End-of-Year Balance
 
 This example will generate the `eoy-balance.csv` file, showing the balance of your account at a given point in time. If you run the example from your IDE, modify the `dateTo` in `EoyBalanceExample.java`. Otherwise, you can run the example from the command line:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Query [Kraken's REST API][1] in Java.
 
 ## Examples
 
-The `examples` folder contains real-world examples that make use of this library. For most examples, you'll need to provide your API keys: rename `api-keys.properties.example`, located in `examples/src/main/resources`, to `api-keys.properties` and fill in your API keys. The examples can be run directly from your IDE, or using the command line:
+The `examples` folder contains real-world examples that make use of this library. For most examples, you'll need to provide your API keys: rename `api-keys.properties.example`, located in `examples/src/main/resources`, to `api-keys.properties` and fill in your API keys. The file is also picked up from the root of the checkout, or from any parent directory of the one the example is run from. The examples can be run directly from your IDE, or using the command line:
 
 ```shell
 # clone and build project

--- a/examples/src/main/java/dev/andstuff/kraken/example/EarnOverviewExample.java
+++ b/examples/src/main/java/dev/andstuff/kraken/example/EarnOverviewExample.java
@@ -3,10 +3,12 @@ package dev.andstuff.kraken.example;
 import static dev.andstuff.kraken.example.helper.CredentialsHelper.readFromFile;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import dev.andstuff.kraken.api.KrakenAPI;
@@ -29,6 +31,9 @@ import lombok.extern.slf4j.Slf4j;
 public class EarnOverviewExample {
 
     private static final int TOP_STRATEGIES_PER_ASSET = 3;
+    private static final DecimalFormat NATIVE_FORMAT = new DecimalFormat("#,##0.####", DecimalFormatSymbols.getInstance(Locale.ROOT));
+    private static final DecimalFormat CONVERTED_FORMAT = new DecimalFormat("#,##0.00", DecimalFormatSymbols.getInstance(Locale.ROOT));
+    private static final DecimalFormat APR_FORMAT = new DecimalFormat("0.000", DecimalFormatSymbols.getInstance(Locale.ROOT));
 
     private final KrakenAPI api;
 
@@ -41,8 +46,8 @@ public class EarnOverviewExample {
         EarnOverview.Report report = new EarnOverview(api).generate();
 
         log.info("Allocated {} {}, earned {} {} since the creation of the account",
-                amount(report.totalAllocated()), report.convertedAsset(),
-                amount(report.totalRewarded()), report.convertedAsset());
+                converted(report.totalAllocated()), report.convertedAsset(),
+                converted(report.totalRewarded()), report.convertedAsset());
 
         log.info("");
         log.info("Assets currently earning");
@@ -54,12 +59,12 @@ public class EarnOverviewExample {
                 allocation.asset(),
                 allocation.strategy() == null ? allocation.allocation().strategyId() : allocation.strategy().id(),
                 allocation.lockType(),
-                allocation.apr(),
+                allocation.apr() == null ? "?" : percentage(allocation.apr()),
                 allocation.yieldSource(),
                 amount(allocation.nativeAmount()),
-                amount(allocation.convertedAmount()),
-                amount(allocation.rewardedAmount()),
-                amount(allocation.accruedReward()))));
+                converted(allocation.convertedAmount()),
+                converted(allocation.rewardedAmount()),
+                converted(allocation.accruedReward()))));
 
         log.info("");
         log.info("Spot balances that could be allocated");
@@ -76,6 +81,7 @@ public class EarnOverviewExample {
                             strategy.yieldSource().type().toString().toLowerCase(),
                             amount(strategy.userMinAllocation()),
                             terms(strategy))));
+            log.info("");
         });
 
         log.info("");
@@ -84,12 +90,16 @@ public class EarnOverviewExample {
 
     private static String earningInPlace(EarnOverview.Opportunity opportunity) {
         return Optional.ofNullable(opportunity.earningInPlace())
-                .map(allocation -> ", already earning %s in flex strategy %s".formatted(allocation.apr(), allocation.strategy().id()))
+                .map(allocation -> ", already earning %s in flex strategy %s".formatted(percentage(allocation.apr()), allocation.strategy().id()))
                 .orElse("");
     }
 
     private static String apr(EarnStrategies.Strategy strategy) {
-        return Optional.ofNullable(strategy.aprEstimate()).map(estimate -> estimate.high() + "%").orElse("?");
+        return Optional.ofNullable(strategy.aprEstimate()).map(estimate -> percentage(estimate.high())).orElse("?");
+    }
+
+    private static String percentage(BigDecimal rate) {
+        return APR_FORMAT.format(rate) + "%";
     }
 
     private static String terms(EarnStrategies.Strategy strategy) {
@@ -109,11 +119,10 @@ public class EarnOverviewExample {
     }
 
     private static String amount(BigDecimal value) {
-        if (value == null) {
-            return "-";
-        }
+        return value == null ? "-" : NATIVE_FORMAT.format(value);
+    }
 
-        BigDecimal stripped = value.stripTrailingZeros();
-        return stripped.scale() > 4 ? stripped.setScale(4, RoundingMode.HALF_UP).toPlainString() : stripped.toPlainString();
+    private static String converted(BigDecimal value) {
+        return value == null ? "-" : CONVERTED_FORMAT.format(value);
     }
 }

--- a/examples/src/main/java/dev/andstuff/kraken/example/EarnOverviewExample.java
+++ b/examples/src/main/java/dev/andstuff/kraken/example/EarnOverviewExample.java
@@ -33,6 +33,7 @@ public class EarnOverviewExample {
     private static final int TOP_STRATEGIES_PER_ASSET = 3;
     private static final DecimalFormat NATIVE_FORMAT = new DecimalFormat("#,##0.####", DecimalFormatSymbols.getInstance(Locale.ROOT));
     private static final DecimalFormat CONVERTED_FORMAT = new DecimalFormat("#,##0.00", DecimalFormatSymbols.getInstance(Locale.ROOT));
+    private static final DecimalFormat PRECISE_FORMAT = new DecimalFormat("#,##0.########", DecimalFormatSymbols.getInstance(Locale.ROOT));
     private static final DecimalFormat APR_FORMAT = new DecimalFormat("0.000", DecimalFormatSymbols.getInstance(Locale.ROOT));
 
     private final KrakenAPI api;
@@ -57,14 +58,29 @@ public class EarnOverviewExample {
 
         report.allocations().forEach(allocation -> log.info(String.format("%-6s %-22s %-8s %-9s %-16s %18s %14s %12s %12s",
                 allocation.asset(),
-                allocation.strategy() == null ? allocation.allocation().strategyId() : allocation.strategy().id(),
+                strategyId(allocation),
                 allocation.lockType(),
-                allocation.apr() == null ? "?" : percentage(allocation.apr()),
+                aprOf(allocation),
                 allocation.yieldSource(),
-                amount(allocation.nativeAmount()),
+                preciseAmount(allocation.nativeAmount()),
                 converted(allocation.convertedAmount()),
                 converted(allocation.rewardedAmount()),
                 converted(allocation.accruedReward()))));
+
+        log.info("");
+        log.info("Assets previously earning");
+        log.info("{}", "-".repeat(120));
+        log.info(String.format("%-6s %-22s %-8s %-9s %-16s %18s %12s",
+                "ASSET", "STRATEGY", "LOCK", "APR", "YIELD", "REWARDS", "EARNED"));
+
+        report.pastAllocations().forEach(allocation -> log.info(String.format("%-6s %-22s %-8s %-9s %-16s %18s %12s",
+                allocation.asset(),
+                strategyId(allocation),
+                allocation.lockType(),
+                aprOf(allocation),
+                allocation.yieldSource(),
+                preciseAmount(allocation.allocation().totalRewarded().nativeAmount()),
+                converted(allocation.rewardedAmount()))));
 
         log.info("");
         log.info("Spot balances that could be allocated");
@@ -86,6 +102,14 @@ public class EarnOverviewExample {
 
         log.info("");
         log.info("Strategies of the flex lock type earn on the spot balance where it sits, no allocation needed.");
+    }
+
+    private static String strategyId(EarnOverview.StrategyAllocation allocation) {
+        return allocation.strategy() == null ? allocation.allocation().strategyId() : allocation.strategy().id();
+    }
+
+    private static String aprOf(EarnOverview.StrategyAllocation allocation) {
+        return allocation.apr() == null ? "?" : percentage(allocation.apr());
     }
 
     private static String earningInPlace(EarnOverview.Opportunity opportunity) {
@@ -120,6 +144,10 @@ public class EarnOverviewExample {
 
     private static String amount(BigDecimal value) {
         return value == null ? "-" : NATIVE_FORMAT.format(value);
+    }
+
+    private static String preciseAmount(BigDecimal value) {
+        return value == null ? "-" : PRECISE_FORMAT.format(value);
     }
 
     private static String converted(BigDecimal value) {

--- a/examples/src/main/java/dev/andstuff/kraken/example/EarnOverviewExample.java
+++ b/examples/src/main/java/dev/andstuff/kraken/example/EarnOverviewExample.java
@@ -1,0 +1,119 @@
+package dev.andstuff.kraken.example;
+
+import static dev.andstuff.kraken.example.helper.CredentialsHelper.readFromFile;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import dev.andstuff.kraken.api.KrakenAPI;
+import dev.andstuff.kraken.api.endpoint.earn.response.EarnStrategies;
+import dev.andstuff.kraken.api.rest.KrakenCredentials;
+import dev.andstuff.kraken.example.earn.EarnOverview;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Prints where the assets of an account are earning, i.e. which earn strategy
+ * holds them and what it has paid so far, and which spot balances could still
+ * be allocated to a strategy that accepts them.
+ * <p>
+ * <i>Note:</i> read-only API key permissions are enough, the example never
+ * allocates or deallocates anything.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class EarnOverviewExample {
+
+    private static final int TOP_STRATEGIES_PER_ASSET = 3;
+
+    private final KrakenAPI api;
+
+    static void main() {
+        KrakenCredentials credentials = readFromFile("/api-keys.properties");
+        new EarnOverviewExample(new KrakenAPI(credentials)).print();
+    }
+
+    public void print() {
+        EarnOverview.Report report = new EarnOverview(api).generate();
+
+        log.info("Allocated {} {}, earned {} {} since the creation of the account",
+                amount(report.totalAllocated()), report.convertedAsset(),
+                amount(report.totalRewarded()), report.convertedAsset());
+
+        log.info("");
+        log.info("Assets currently earning");
+        log.info("{}", "-".repeat(120));
+        log.info(String.format("%-6s %-22s %-8s %-9s %-16s %18s %14s %12s %12s",
+                "ASSET", "STRATEGY", "LOCK", "APR", "YIELD", "ALLOCATED", "VALUE", "EARNED", "PERIOD"));
+
+        report.allocations().forEach(allocation -> log.info(String.format("%-6s %-22s %-8s %-9s %-16s %18s %14s %12s %12s",
+                allocation.asset(),
+                allocation.strategy() == null ? allocation.allocation().strategyId() : allocation.strategy().id(),
+                allocation.lockType(),
+                allocation.apr(),
+                allocation.yieldSource(),
+                amount(allocation.nativeAmount()),
+                amount(allocation.convertedAmount()),
+                amount(allocation.rewardedAmount()),
+                amount(allocation.accruedReward()))));
+
+        log.info("");
+        log.info("Spot balances that could be allocated");
+        log.info("{}", "-".repeat(120));
+
+        report.opportunities().forEach(opportunity -> {
+            log.info("{} {} available{}", amount(opportunity.spotBalance()), opportunity.asset(), earningInPlace(opportunity));
+            opportunity.strategies().stream()
+                    .limit(TOP_STRATEGIES_PER_ASSET)
+                    .forEach(strategy -> log.info(String.format("    %-22s %-8s %-9s %-16s min %s %s",
+                            strategy.id(),
+                            strategy.lockType().type().toString().toLowerCase(),
+                            apr(strategy),
+                            strategy.yieldSource().type().toString().toLowerCase(),
+                            amount(strategy.userMinAllocation()),
+                            terms(strategy))));
+        });
+
+        log.info("");
+        log.info("Strategies of the flex lock type earn on the spot balance where it sits, no allocation needed.");
+    }
+
+    private static String earningInPlace(EarnOverview.Opportunity opportunity) {
+        return Optional.ofNullable(opportunity.earningInPlace())
+                .map(allocation -> ", already earning %s in flex strategy %s".formatted(allocation.apr(), allocation.strategy().id()))
+                .orElse("");
+    }
+
+    private static String apr(EarnStrategies.Strategy strategy) {
+        return Optional.ofNullable(strategy.aprEstimate()).map(estimate -> estimate.high() + "%").orElse("?");
+    }
+
+    private static String terms(EarnStrategies.Strategy strategy) {
+        EarnStrategies.LockType lockType = strategy.lockType();
+
+        List<String> terms = new ArrayList<>();
+        Optional.ofNullable(lockType.durationMonths()).ifPresent(months -> terms.add("locked %d months".formatted(months)));
+        Optional.ofNullable(lockType.bondingPeriod()).filter(period -> !period.isZero()).ifPresent(period -> terms.add("bonding " + days(period)));
+        Optional.ofNullable(lockType.unbondingPeriod()).filter(period -> !period.isZero()).ifPresent(period -> terms.add("unbonding " + days(period)));
+        Optional.ofNullable(lockType.payoutFrequency()).ifPresent(frequency -> terms.add("paid every " + days(frequency)));
+
+        return String.join(", ", terms);
+    }
+
+    private static String days(Duration duration) {
+        return duration.toDays() > 0 ? duration.toDays() + "d" : duration.toHours() + "h";
+    }
+
+    private static String amount(BigDecimal value) {
+        if (value == null) {
+            return "-";
+        }
+
+        BigDecimal stripped = value.stripTrailingZeros();
+        return stripped.scale() > 4 ? stripped.setScale(4, RoundingMode.HALF_UP).toPlainString() : stripped.toPlainString();
+    }
+}

--- a/examples/src/main/java/dev/andstuff/kraken/example/earn/AssetCodes.java
+++ b/examples/src/main/java/dev/andstuff/kraken/example/earn/AssetCodes.java
@@ -1,0 +1,42 @@
+package dev.andstuff.kraken.example.earn;
+
+import java.util.Map;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class AssetCodes {
+
+    private static final Map<String, String> LEGACY_CODES = Map.ofEntries(
+            Map.entry("XXBT", "BTC"),
+            Map.entry("XBT", "BTC"),
+            Map.entry("XXDG", "DOGE"),
+            Map.entry("XDG", "DOGE"),
+            Map.entry("XXLM", "XLM"),
+            Map.entry("XXMR", "XMR"),
+            Map.entry("XXRP", "XRP"),
+            Map.entry("XETH", "ETH"),
+            Map.entry("XETC", "ETC"),
+            Map.entry("XLTC", "LTC"),
+            Map.entry("XNMC", "NMC"),
+            Map.entry("XZEC", "ZEC"),
+            Map.entry("XREP", "REP"),
+            Map.entry("XMLN", "MLN"),
+            Map.entry("ZUSD", "USD"),
+            Map.entry("ZEUR", "EUR"),
+            Map.entry("ZGBP", "GBP"),
+            Map.entry("ZCAD", "CAD"),
+            Map.entry("ZJPY", "JPY"),
+            Map.entry("ZAUD", "AUD"),
+            Map.entry("ZCHF", "CHF"));
+
+    public static String normalize(String krakenCode) {
+        String code = krakenCode.split("\\.")[0].replaceAll("\\d+$", "");
+        return LEGACY_CODES.getOrDefault(code, code);
+    }
+
+    public static boolean isEarnWallet(String krakenCode) {
+        return krakenCode.contains(".");
+    }
+}

--- a/examples/src/main/java/dev/andstuff/kraken/example/earn/EarnOverview.java
+++ b/examples/src/main/java/dev/andstuff/kraken/example/earn/EarnOverview.java
@@ -36,7 +36,7 @@ public class EarnOverview {
                 .collect(toMap(EarnStrategies.Strategy::id, identity()));
 
         List<ActiveAllocation> active = allocations.items().stream()
-                .filter(allocation -> isPositive(allocation.amountAllocated().total().nativeAmount()))
+                .filter(allocation -> isAllocated(allocation.amountAllocated().total()))
                 .map(allocation -> new ActiveAllocation(allocation, strategiesById.get(allocation.strategyId())))
                 .sorted(comparing(ActiveAllocation::convertedAmount).reversed())
                 .toList();
@@ -89,6 +89,10 @@ public class EarnOverview {
         return Optional.ofNullable(strategy.aprEstimate())
                 .map(EarnStrategies.AprEstimate::high)
                 .orElse(BigDecimal.ZERO);
+    }
+
+    private static boolean isAllocated(EarnAllocations.Amount amount) {
+        return isPositive(amount.nativeAmount()) && (amount.converted() == null || isPositive(amount.converted()));
     }
 
     private static boolean isPositive(BigDecimal amount) {

--- a/examples/src/main/java/dev/andstuff/kraken/example/earn/EarnOverview.java
+++ b/examples/src/main/java/dev/andstuff/kraken/example/earn/EarnOverview.java
@@ -136,8 +136,8 @@ public class EarnOverview {
                     .orElse("unknown");
         }
 
-        public String apr() {
-            return Optional.ofNullable(strategy).map(EarnOverview::aprOf).map(apr -> apr + "%").orElse("?");
+        public BigDecimal apr() {
+            return Optional.ofNullable(strategy).map(EarnOverview::aprOf).orElse(null);
         }
 
         public String yieldSource() {

--- a/examples/src/main/java/dev/andstuff/kraken/example/earn/EarnOverview.java
+++ b/examples/src/main/java/dev/andstuff/kraken/example/earn/EarnOverview.java
@@ -35,10 +35,19 @@ public class EarnOverview {
         Map<String, EarnStrategies.Strategy> strategiesById = strategies.stream()
                 .collect(toMap(EarnStrategies.Strategy::id, identity()));
 
-        List<ActiveAllocation> active = allocations.items().stream()
-                .filter(allocation -> isAllocated(allocation.amountAllocated().total()))
-                .map(allocation -> new ActiveAllocation(allocation, strategiesById.get(allocation.strategyId())))
-                .sorted(comparing(ActiveAllocation::convertedAmount).reversed())
+        List<StrategyAllocation> all = allocations.items().stream()
+                .map(allocation -> new StrategyAllocation(allocation, strategiesById.get(allocation.strategyId())))
+                .toList();
+
+        List<StrategyAllocation> active = all.stream()
+                .filter(StrategyAllocation::isAllocated)
+                .sorted(comparing(StrategyAllocation::convertedAmount).reversed())
+                .toList();
+
+        List<StrategyAllocation> past = all.stream()
+                .filter(allocation -> !allocation.isAllocated())
+                .filter(allocation -> isPositive(allocation.rewardedAmount()))
+                .sorted(comparing(StrategyAllocation::rewardedAmount).reversed())
                 .toList();
 
         List<Opportunity> opportunities = spotBalances().entrySet().stream()
@@ -51,7 +60,7 @@ public class EarnOverview {
                 .sorted(comparing(Opportunity::bestApr).reversed())
                 .toList();
 
-        return new Report(allocations.convertedAsset(), allocations.totalAllocated(), allocations.totalRewarded(), active, opportunities);
+        return new Report(allocations.convertedAsset(), allocations.totalAllocated(), allocations.totalRewarded(), active, past, opportunities);
     }
 
     private Map<String, BigDecimal> spotBalances() {
@@ -73,7 +82,7 @@ public class EarnOverview {
                 .toList();
     }
 
-    private static ActiveAllocation flexAllocationOf(List<ActiveAllocation> allocations, String asset) {
+    private static StrategyAllocation flexAllocationOf(List<StrategyAllocation> allocations, String asset) {
         return allocations.stream()
                 .filter(allocation -> asset.equals(AssetCodes.normalize(allocation.asset())))
                 .filter(allocation -> "flex".equals(allocation.lockType()))
@@ -91,10 +100,6 @@ public class EarnOverview {
                 .orElse(BigDecimal.ZERO);
     }
 
-    private static boolean isAllocated(EarnAllocations.Amount amount) {
-        return isPositive(amount.nativeAmount()) && (amount.converted() == null || isPositive(amount.converted()));
-    }
-
     private static boolean isPositive(BigDecimal amount) {
         return amount != null && amount.compareTo(BigDecimal.ZERO) > 0;
     }
@@ -102,11 +107,16 @@ public class EarnOverview {
     public record Report(String convertedAsset,
                          BigDecimal totalAllocated,
                          BigDecimal totalRewarded,
-                         List<ActiveAllocation> allocations,
+                         List<StrategyAllocation> allocations,
+                         List<StrategyAllocation> pastAllocations,
                          List<Opportunity> opportunities) {}
 
-    public record ActiveAllocation(EarnAllocations.Allocation allocation,
-                                   EarnStrategies.Strategy strategy) {
+    public record StrategyAllocation(EarnAllocations.Allocation allocation,
+                                     EarnStrategies.Strategy strategy) {
+
+        public boolean isAllocated() {
+            return isPositive(allocation.amountAllocated().total().nativeAmount());
+        }
 
         public String asset() {
             return allocation.nativeAsset();
@@ -150,7 +160,7 @@ public class EarnOverview {
     public record Opportunity(String asset,
                               BigDecimal spotBalance,
                               List<EarnStrategies.Strategy> strategies,
-                              ActiveAllocation earningInPlace) {
+                              StrategyAllocation earningInPlace) {
 
         public BigDecimal bestApr() {
             return strategies.stream().map(EarnOverview::aprOf).max(BigDecimal::compareTo).orElse(BigDecimal.ZERO);

--- a/examples/src/main/java/dev/andstuff/kraken/example/earn/EarnOverview.java
+++ b/examples/src/main/java/dev/andstuff/kraken/example/earn/EarnOverview.java
@@ -1,0 +1,155 @@
+package dev.andstuff.kraken.example.earn;
+
+import static java.util.Comparator.comparing;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import dev.andstuff.kraken.api.KrakenAPI;
+import dev.andstuff.kraken.api.endpoint.earn.response.EarnAllocations;
+import dev.andstuff.kraken.api.endpoint.earn.response.EarnStrategies;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Crosses the earn allocations of an account with the strategies Kraken offers
+ * and with the spot balances, to tell where the assets of the account are
+ * earning and what else could be allocated.
+ */
+@RequiredArgsConstructor
+public class EarnOverview {
+
+    private static final String FEE_ASSET = "KFEE";
+
+    private final KrakenAPI api;
+
+    public Report generate() {
+        List<EarnStrategies.Strategy> strategies = api.earnStrategies().items();
+        EarnAllocations allocations = api.earnAllocations();
+
+        Map<String, EarnStrategies.Strategy> strategiesById = strategies.stream()
+                .collect(toMap(EarnStrategies.Strategy::id, identity()));
+
+        List<ActiveAllocation> active = allocations.items().stream()
+                .filter(allocation -> isPositive(allocation.amountAllocated().total().nativeAmount()))
+                .map(allocation -> new ActiveAllocation(allocation, strategiesById.get(allocation.strategyId())))
+                .sorted(comparing(ActiveAllocation::convertedAmount).reversed())
+                .toList();
+
+        List<Opportunity> opportunities = spotBalances().entrySet().stream()
+                .map(balance -> new Opportunity(
+                        balance.getKey(),
+                        balance.getValue(),
+                        allocatableStrategiesFor(strategies, balance.getKey(), balance.getValue()),
+                        flexAllocationOf(active, balance.getKey())))
+                .filter(opportunity -> !opportunity.strategies().isEmpty())
+                .sorted(comparing(Opportunity::bestApr).reversed())
+                .toList();
+
+        return new Report(allocations.convertedAsset(), allocations.totalAllocated(), allocations.totalRewarded(), active, opportunities);
+    }
+
+    private Map<String, BigDecimal> spotBalances() {
+        JsonNode balance = api.query(KrakenAPI.Private.BALANCE);
+
+        return balance.properties().stream()
+                .filter(asset -> !AssetCodes.isEarnWallet(asset.getKey()))
+                .filter(asset -> !FEE_ASSET.equals(asset.getKey()))
+                .filter(asset -> isPositive(new BigDecimal(asset.getValue().asText())))
+                .collect(toMap(asset -> AssetCodes.normalize(asset.getKey()), asset -> new BigDecimal(asset.getValue().asText()), BigDecimal::add));
+    }
+
+    private static List<EarnStrategies.Strategy> allocatableStrategiesFor(List<EarnStrategies.Strategy> strategies, String asset, BigDecimal spotBalance) {
+        return strategies.stream()
+                .filter(EarnStrategies.Strategy::canAllocate)
+                .filter(strategy -> asset.equals(AssetCodes.normalize(strategy.asset())))
+                .filter(strategy -> reaches(spotBalance, strategy.userMinAllocation()))
+                .sorted(comparing(EarnOverview::aprOf).reversed())
+                .toList();
+    }
+
+    private static ActiveAllocation flexAllocationOf(List<ActiveAllocation> allocations, String asset) {
+        return allocations.stream()
+                .filter(allocation -> asset.equals(AssetCodes.normalize(allocation.asset())))
+                .filter(allocation -> "flex".equals(allocation.lockType()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static boolean reaches(BigDecimal spotBalance, BigDecimal minAllocation) {
+        return minAllocation == null || spotBalance.compareTo(minAllocation) >= 0;
+    }
+
+    private static BigDecimal aprOf(EarnStrategies.Strategy strategy) {
+        return Optional.ofNullable(strategy.aprEstimate())
+                .map(EarnStrategies.AprEstimate::high)
+                .orElse(BigDecimal.ZERO);
+    }
+
+    private static boolean isPositive(BigDecimal amount) {
+        return amount != null && amount.compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    public record Report(String convertedAsset,
+                         BigDecimal totalAllocated,
+                         BigDecimal totalRewarded,
+                         List<ActiveAllocation> allocations,
+                         List<Opportunity> opportunities) {}
+
+    public record ActiveAllocation(EarnAllocations.Allocation allocation,
+                                   EarnStrategies.Strategy strategy) {
+
+        public String asset() {
+            return allocation.nativeAsset();
+        }
+
+        public BigDecimal nativeAmount() {
+            return allocation.amountAllocated().total().nativeAmount();
+        }
+
+        public BigDecimal convertedAmount() {
+            return allocation.amountAllocated().total().converted();
+        }
+
+        public BigDecimal rewardedAmount() {
+            return allocation.totalRewarded().converted();
+        }
+
+        public BigDecimal accruedReward() {
+            return Optional.ofNullable(allocation.payout())
+                    .map(payout -> payout.accumulatedReward().converted())
+                    .orElse(BigDecimal.ZERO);
+        }
+
+        public String lockType() {
+            return Optional.ofNullable(strategy)
+                    .map(found -> found.lockType().type().toString().toLowerCase())
+                    .orElse("unknown");
+        }
+
+        public String apr() {
+            return Optional.ofNullable(strategy).map(EarnOverview::aprOf).map(apr -> apr + "%").orElse("?");
+        }
+
+        public String yieldSource() {
+            return Optional.ofNullable(strategy)
+                    .map(found -> found.yieldSource().type().toString().toLowerCase())
+                    .orElse("unknown");
+        }
+    }
+
+    public record Opportunity(String asset,
+                              BigDecimal spotBalance,
+                              List<EarnStrategies.Strategy> strategies,
+                              ActiveAllocation earningInPlace) {
+
+        public BigDecimal bestApr() {
+            return strategies.stream().map(EarnOverview::aprOf).max(BigDecimal::compareTo).orElse(BigDecimal.ZERO);
+        }
+    }
+}

--- a/examples/src/main/java/dev/andstuff/kraken/example/helper/CredentialsHelper.java
+++ b/examples/src/main/java/dev/andstuff/kraken/example/helper/CredentialsHelper.java
@@ -2,6 +2,8 @@ package dev.andstuff.kraken.example.helper;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import dev.andstuff.kraken.api.rest.KrakenCredentials;
@@ -12,8 +14,7 @@ import lombok.NoArgsConstructor;
 public final class CredentialsHelper {
 
     public static KrakenCredentials readFromFile(String path) {
-        try {
-            InputStream stream = CredentialsHelper.class.getResourceAsStream(path);
+        try (InputStream stream = open(path)) {
             Properties properties = new Properties();
             properties.load(stream);
             return new KrakenCredentials(properties.getProperty("key"), properties.getProperty("secret"));
@@ -21,5 +22,24 @@ public final class CredentialsHelper {
         catch (IOException e) {
             throw new IllegalStateException("Could not read properties from file: %s".formatted(path), e);
         }
+    }
+
+    private static InputStream open(String path) throws IOException {
+        InputStream stream = CredentialsHelper.class.getResourceAsStream(path);
+        return stream != null ? stream : Files.newInputStream(findNearby(path));
+    }
+
+    private static Path findNearby(String path) {
+        String fileName = Path.of(path).getFileName().toString();
+
+        for (Path directory = Path.of("").toAbsolutePath(); directory != null; directory = directory.getParent()) {
+            Path candidate = directory.resolve(fileName);
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+        }
+
+        throw new IllegalStateException("Could not find %s on the classpath, nor in %s or any of its parent directories. Copy examples/src/main/resources/api-keys.properties.example to api-keys.properties and fill in your API keys."
+                .formatted(fileName, Path.of("").toAbsolutePath()));
     }
 }

--- a/examples/src/main/resources/log4j2.xml
+++ b/examples/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Configuration status="warn">
     <Properties>
-        <Property name="defaultPattern">[%d{ISO8601}] %-5.5p [%-20.20c{1.}] [%-7.7t] %m%n</Property>
+        <Property name="defaultPattern">[%d{ISO8601}] %-5.5p [%-20.20c{1.}] %m%n</Property>
     </Properties>
 
     <Appenders>

--- a/library/src/main/java/dev/andstuff/kraken/api/KrakenAPI.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/KrakenAPI.java
@@ -24,6 +24,19 @@ import dev.andstuff.kraken.api.endpoint.account.response.LedgerEntry;
 import dev.andstuff.kraken.api.endpoint.account.response.LedgerInfo;
 import dev.andstuff.kraken.api.endpoint.account.response.Report;
 import dev.andstuff.kraken.api.endpoint.account.response.ReportRequest;
+import dev.andstuff.kraken.api.endpoint.earn.EarnAllocateEndpoint;
+import dev.andstuff.kraken.api.endpoint.earn.EarnAllocateStatusEndpoint;
+import dev.andstuff.kraken.api.endpoint.earn.EarnAllocationsEndpoint;
+import dev.andstuff.kraken.api.endpoint.earn.EarnDeallocateEndpoint;
+import dev.andstuff.kraken.api.endpoint.earn.EarnDeallocateStatusEndpoint;
+import dev.andstuff.kraken.api.endpoint.earn.EarnStrategiesEndpoint;
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnAllocationParams;
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnAllocationsParams;
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnStatusParams;
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnStrategiesParams;
+import dev.andstuff.kraken.api.endpoint.earn.response.AllocationStatus;
+import dev.andstuff.kraken.api.endpoint.earn.response.EarnAllocations;
+import dev.andstuff.kraken.api.endpoint.earn.response.EarnStrategies;
 import dev.andstuff.kraken.api.endpoint.market.AssetInfoEndpoint;
 import dev.andstuff.kraken.api.endpoint.market.AssetPairEndpoint;
 import dev.andstuff.kraken.api.endpoint.market.ServerTimeEndpoint;
@@ -361,6 +374,92 @@ public class KrakenAPI {
      */
     public AccountTransfer accountTransfer(AccountTransferParams params) {
         return query(new AccountTransferEndpoint(params));
+    }
+
+    /**
+     * Queries the private {@code Earn/Strategies} endpoint, returning the first page of earn strategies available to the account.
+     *
+     * @return the strategies and the cursor of the next page
+     * @throws KrakenException if Kraken returns an error
+     */
+    public EarnStrategies earnStrategies() {
+        return earnStrategies(EarnStrategiesParams.builder().build());
+    }
+
+    /**
+     * Queries the private {@code Earn/Strategies} endpoint. Strategies restricted by the tier of the account are returned with {@link EarnStrategies.Strategy#canAllocate()} set to {@code false}.
+     *
+     * @param params the asset, lock type and pagination parameters restricting the strategies returned
+     * @return the strategies and the cursor of the next page
+     * @throws KrakenException if Kraken returns an error
+     */
+    public EarnStrategies earnStrategies(EarnStrategiesParams params) {
+        return query(new EarnStrategiesEndpoint(params));
+    }
+
+    /**
+     * Queries the private {@code Earn/Allocations} endpoint, returning the earn allocations of the account with amounts converted to USD.
+     *
+     * @return the allocations, one per strategy
+     * @throws KrakenException if Kraken returns an error
+     */
+    public EarnAllocations earnAllocations() {
+        return earnAllocations(EarnAllocationsParams.builder().build());
+    }
+
+    /**
+     * Queries the private {@code Earn/Allocations} endpoint.
+     *
+     * @param params the sort order, the asset amounts are converted to and whether zero allocations are hidden
+     * @return the allocations, one per strategy
+     * @throws KrakenException if Kraken returns an error
+     */
+    public EarnAllocations earnAllocations(EarnAllocationsParams params) {
+        return query(new EarnAllocationsEndpoint(params));
+    }
+
+    /**
+     * Queries the private {@code Earn/Allocate} endpoint, allocating funds to an earn strategy. It requires an API key with the earn funds permission and returns as soon as Kraken accepts the request: use {@link #earnAllocateStatus(String)} to know when the allocation completed.
+     *
+     * @param params the strategy and the amount to allocate
+     * @return whether Kraken accepted the allocation request
+     * @throws KrakenException if Kraken returns an error
+     */
+    public boolean earnAllocate(EarnAllocationParams params) {
+        return query(new EarnAllocateEndpoint(params));
+    }
+
+    /**
+     * Queries the private {@code Earn/Deallocate} endpoint, removing funds from an earn strategy. It requires an API key with the earn funds permission and returns as soon as Kraken accepts the request: use {@link #earnDeallocateStatus(String)} to know when the deallocation completed.
+     *
+     * @param params the strategy and the amount to deallocate
+     * @return whether Kraken accepted the deallocation request
+     * @throws KrakenException if Kraken returns an error
+     */
+    public boolean earnDeallocate(EarnAllocationParams params) {
+        return query(new EarnDeallocateEndpoint(params));
+    }
+
+    /**
+     * Queries the private {@code Earn/AllocateStatus} endpoint, telling whether the last allocation to a strategy is still in progress.
+     *
+     * @param strategyId the identifier of the strategy funds were allocated to
+     * @return the status of the allocation
+     * @throws KrakenException if Kraken returns an error
+     */
+    public AllocationStatus earnAllocateStatus(String strategyId) {
+        return query(new EarnAllocateStatusEndpoint(EarnStatusParams.of(strategyId)));
+    }
+
+    /**
+     * Queries the private {@code Earn/DeallocateStatus} endpoint, telling whether the last deallocation from a strategy is still in progress.
+     *
+     * @param strategyId the identifier of the strategy funds were deallocated from
+     * @return the status of the deallocation
+     * @throws KrakenException if Kraken returns an error
+     */
+    public AllocationStatus earnDeallocateStatus(String strategyId) {
+        return query(new EarnDeallocateStatusEndpoint(EarnStatusParams.of(strategyId)));
     }
 
     /* Query unimplemented endpoints */

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnAllocateEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnAllocateEndpoint.java
@@ -1,0 +1,21 @@
+package dev.andstuff.kraken.api.endpoint.earn;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnAllocationParams;
+import dev.andstuff.kraken.api.endpoint.priv.PrivateEndpoint;
+
+/**
+ * The private {@code Earn/Allocate} endpoint, allocating funds to an earn strategy. It requires an API key with the earn funds permission and returns before the allocation completes.
+ */
+public class EarnAllocateEndpoint extends PrivateEndpoint<Boolean> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the strategy and the amount to allocate
+     */
+    public EarnAllocateEndpoint(EarnAllocationParams params) {
+        super("Earn/Allocate", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnAllocateStatusEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnAllocateStatusEndpoint.java
@@ -1,0 +1,22 @@
+package dev.andstuff.kraken.api.endpoint.earn;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnStatusParams;
+import dev.andstuff.kraken.api.endpoint.earn.response.AllocationStatus;
+import dev.andstuff.kraken.api.endpoint.priv.PrivateEndpoint;
+
+/**
+ * The private {@code Earn/AllocateStatus} endpoint, telling whether the last allocation to a strategy is still in progress.
+ */
+public class EarnAllocateStatusEndpoint extends PrivateEndpoint<AllocationStatus> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the strategy the allocation was made to
+     */
+    public EarnAllocateStatusEndpoint(EarnStatusParams params) {
+        super("Earn/AllocateStatus", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnAllocationsEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnAllocationsEndpoint.java
@@ -1,0 +1,22 @@
+package dev.andstuff.kraken.api.endpoint.earn;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnAllocationsParams;
+import dev.andstuff.kraken.api.endpoint.earn.response.EarnAllocations;
+import dev.andstuff.kraken.api.endpoint.priv.PrivateEndpoint;
+
+/**
+ * The private {@code Earn/Allocations} endpoint, listing the earn allocations of the account.
+ */
+public class EarnAllocationsEndpoint extends PrivateEndpoint<EarnAllocations> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the sort order, converted asset and zero allocation parameters
+     */
+    public EarnAllocationsEndpoint(EarnAllocationsParams params) {
+        super("Earn/Allocations", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnDeallocateEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnDeallocateEndpoint.java
@@ -1,0 +1,21 @@
+package dev.andstuff.kraken.api.endpoint.earn;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnAllocationParams;
+import dev.andstuff.kraken.api.endpoint.priv.PrivateEndpoint;
+
+/**
+ * The private {@code Earn/Deallocate} endpoint, removing funds from an earn strategy. It requires an API key with the earn funds permission and returns before the deallocation completes.
+ */
+public class EarnDeallocateEndpoint extends PrivateEndpoint<Boolean> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the strategy and the amount to deallocate
+     */
+    public EarnDeallocateEndpoint(EarnAllocationParams params) {
+        super("Earn/Deallocate", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnDeallocateStatusEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnDeallocateStatusEndpoint.java
@@ -1,0 +1,22 @@
+package dev.andstuff.kraken.api.endpoint.earn;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnStatusParams;
+import dev.andstuff.kraken.api.endpoint.earn.response.AllocationStatus;
+import dev.andstuff.kraken.api.endpoint.priv.PrivateEndpoint;
+
+/**
+ * The private {@code Earn/DeallocateStatus} endpoint, telling whether the last deallocation from a strategy is still in progress.
+ */
+public class EarnDeallocateStatusEndpoint extends PrivateEndpoint<AllocationStatus> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the strategy the deallocation was made from
+     */
+    public EarnDeallocateStatusEndpoint(EarnStatusParams params) {
+        super("Earn/DeallocateStatus", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnStrategiesEndpoint.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/EarnStrategiesEndpoint.java
@@ -1,0 +1,22 @@
+package dev.andstuff.kraken.api.endpoint.earn;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import dev.andstuff.kraken.api.endpoint.earn.params.EarnStrategiesParams;
+import dev.andstuff.kraken.api.endpoint.earn.response.EarnStrategies;
+import dev.andstuff.kraken.api.endpoint.priv.PrivateEndpoint;
+
+/**
+ * The private {@code Earn/Strategies} endpoint, listing the earn strategies available to the account.
+ */
+public class EarnStrategiesEndpoint extends PrivateEndpoint<EarnStrategies> {
+
+    /**
+     * Creates the endpoint.
+     *
+     * @param params the asset, lock type and pagination parameters restricting the strategies returned
+     */
+    public EarnStrategiesEndpoint(EarnStrategiesParams params) {
+        super("Earn/Strategies", params, new TypeReference<>() {});
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnAllocationParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnAllocationParams.java
@@ -1,0 +1,32 @@
+package dev.andstuff.kraken.api.endpoint.earn.params;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.andstuff.kraken.api.endpoint.priv.PostParams;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The parameters of the {@code Earn/Allocate} and {@code Earn/Deallocate} endpoints, both taking a strategy and an amount expressed in the native asset of that strategy.
+ */
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class EarnAllocationParams extends PostParams {
+
+    @NonNull
+    private final String strategyId;
+
+    @NonNull
+    private final BigDecimal amount;
+
+    @Override
+    protected Map<String, String> params() {
+        Map<String, String> params = new HashMap<>();
+        params.put("strategy_id", strategyId);
+        params.put("amount", amount.toPlainString());
+        return params;
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnAllocationsParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnAllocationsParams.java
@@ -1,0 +1,29 @@
+package dev.andstuff.kraken.api.endpoint.earn.params;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.andstuff.kraken.api.endpoint.priv.PostParams;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * The parameters of the {@code Earn/Allocations} endpoint. All of them are optional: Kraken sorts by allocated amount descending, converts amounts to USD and returns strategies with a zero allocation unless told otherwise.
+ */
+@Getter
+@Builder(toBuilder = true)
+public class EarnAllocationsParams extends PostParams {
+
+    private final Boolean ascending;
+    private final String convertedAsset;
+    private final Boolean hideZeroAllocations;
+
+    @Override
+    protected Map<String, String> params() {
+        Map<String, String> params = new HashMap<>();
+        putIfNonNull(params, "ascending", ascending);
+        putIfNonNull(params, "converted_asset", convertedAsset);
+        putIfNonNull(params, "hide_zero_allocations", hideZeroAllocations);
+        return params;
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnStatusParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnStatusParams.java
@@ -1,0 +1,27 @@
+package dev.andstuff.kraken.api.endpoint.earn.params;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.andstuff.kraken.api.endpoint.priv.PostParams;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The parameters of the {@code Earn/AllocateStatus} and {@code Earn/DeallocateStatus} endpoints.
+ */
+@Getter
+@RequiredArgsConstructor(staticName = "of")
+public class EarnStatusParams extends PostParams {
+
+    @NonNull
+    private final String strategyId;
+
+    @Override
+    protected Map<String, String> params() {
+        Map<String, String> params = new HashMap<>();
+        params.put("strategy_id", strategyId);
+        return params;
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnStrategiesParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnStrategiesParams.java
@@ -1,0 +1,34 @@
+package dev.andstuff.kraken.api.endpoint.earn.params;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dev.andstuff.kraken.api.endpoint.priv.PostParams;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * The parameters of the {@code Earn/Strategies} endpoint. All of them are optional: strategies can be restricted to an asset and to lock types, and paged through with the cursor returned by the previous call.
+ */
+@Getter
+@Builder(toBuilder = true)
+public class EarnStrategiesParams extends PostParams {
+
+    private final Boolean ascending;
+    private final String asset;
+    private final String cursor;
+    private final Integer limit;
+    private final List<LockType> lockTypes;
+
+    @Override
+    protected Map<String, String> params() {
+        Map<String, String> params = new HashMap<>();
+        putIfNonNull(params, "ascending", ascending);
+        putIfNonNull(params, "asset", asset);
+        putIfNonNull(params, "cursor", cursor);
+        putIfNonNull(params, "limit", limit);
+        putIfNonNull(params, "lock_type", lockTypes, types -> String.join(",", types.stream().map(type -> type.toString().toLowerCase()).toList()));
+        return params;
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnStrategiesParams.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/EarnStrategiesParams.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
- * The parameters of the {@code Earn/Strategies} endpoint. All of them are optional: strategies can be restricted to an asset and to lock types, and paged through with the cursor returned by the previous call.
+ * The parameters of the {@code Earn/Strategies} endpoint. All of them are optional: strategies can be restricted to an asset and to lock types, and paged through with the cursor returned by the previous call, which Kraken currently ignores, returning every strategy in one page. Lock types are sent as the indexed array Kraken expects, i.e. {@code lock_type[0]}, {@code lock_type[1]} and so on.
  */
 @Getter
 @Builder(toBuilder = true)
@@ -28,7 +28,17 @@ public class EarnStrategiesParams extends PostParams {
         putIfNonNull(params, "asset", asset);
         putIfNonNull(params, "cursor", cursor);
         putIfNonNull(params, "limit", limit);
-        putIfNonNull(params, "lock_type", lockTypes, types -> String.join(",", types.stream().map(type -> type.toString().toLowerCase()).toList()));
+        putLockTypes(params);
         return params;
+    }
+
+    private void putLockTypes(Map<String, String> params) {
+        if (lockTypes == null) {
+            return;
+        }
+
+        for (int index = 0; index < lockTypes.size(); index++) {
+            params.put("lock_type[%d]".formatted(index), lockTypes.get(index).toString().toLowerCase());
+        }
     }
 }

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/LockType.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/params/LockType.java
@@ -1,0 +1,8 @@
+package dev.andstuff.kraken.api.endpoint.earn.params;
+
+/**
+ * The lock type an {@code Earn/Strategies} request can be filtered on.
+ */
+public enum LockType {
+    FLEX, BONDED, TIMED, INSTANT
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/AllocationStatus.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/AllocationStatus.java
@@ -1,0 +1,8 @@
+package dev.andstuff.kraken.api.endpoint.earn.response;
+
+/**
+ * The response of the {@code Earn/AllocateStatus} and {@code Earn/DeallocateStatus} endpoints.
+ *
+ * @param pending whether an allocation or deallocation is still in progress on the strategy
+ */
+public record AllocationStatus(boolean pending) {}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/AssetClass.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/AssetClass.java
@@ -1,0 +1,14 @@
+package dev.andstuff.kraken.api.endpoint.earn.response;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+/**
+ * The class of an asset an earn strategy accepts, or an allocation is made in.
+ */
+public enum AssetClass {
+    CURRENCY,
+    TOKENIZED_ASSET,
+
+    @JsonEnumDefaultValue
+    UNKNOWN
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/EarnAllocations.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/EarnAllocations.java
@@ -1,0 +1,103 @@
+package dev.andstuff.kraken.api.endpoint.earn.response;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The response of the {@code Earn/Allocations} endpoint, i.e. the earn allocations of the account.
+ *
+ * @param convertedAsset the asset the converted amounts are expressed in
+ * @param totalAllocated the total amount allocated, in the converted asset
+ * @param totalRewarded the total amount earned since the creation of the account, in the converted asset
+ * @param nextCursor the cursor of the next page, {@code null} on the last one
+ * @param items the allocations, one per strategy
+ */
+public record EarnAllocations(@JsonProperty("converted_asset") String convertedAsset,
+                              @JsonProperty("total_allocated") BigDecimal totalAllocated,
+                              @JsonProperty("total_rewarded") BigDecimal totalRewarded,
+                              @JsonProperty("next_cursor") String nextCursor,
+                              List<Allocation> items) {
+
+    /**
+     * The allocation of the account to a single strategy.
+     *
+     * @param strategyId the identifier of the strategy
+     * @param nativeAsset the asset allocated to the strategy
+     * @param amountAllocated the allocated amount, split by state
+     * @param totalRewarded the amount earned on the strategy since the creation of the account
+     * @param payout the reward period in progress, {@code null} for strategies that have none
+     */
+    public record Allocation(@JsonProperty("strategy_id") String strategyId,
+                             @JsonProperty("native_asset") String nativeAsset,
+                             @JsonProperty("amount_allocated") AmountAllocated amountAllocated,
+                             @JsonProperty("total_rewarded") Amount totalRewarded,
+                             Payout payout) {}
+
+    /**
+     * The amount allocated to a strategy, split by the state the funds are in. Kraken omits the states that don't apply to the strategy.
+     *
+     * @param bonding the funds bonding, not earning rewards yet
+     * @param allocated the funds earning rewards
+     * @param exitQueue the funds queued for unbonding, Ethereum only
+     * @param unbonding the funds unbonding, on their way back to the spot balance
+     * @param pending the funds of an allocation or deallocation still in progress
+     * @param total the sum of all states
+     */
+    public record AmountAllocated(State bonding,
+                                  Amount allocated,
+                                  @JsonProperty("exit_queue") State exitQueue,
+                                  State unbonding,
+                                  Amount pending,
+                                  Amount total) {}
+
+    /**
+     * The funds of a state that holds them for a period, i.e. bonding, unbonding or exit queue.
+     *
+     * @param nativeAmount the amount, in the asset of the strategy
+     * @param converted the amount, in the converted asset
+     * @param allocationCount the number of allocations in this state
+     * @param allocations the allocations in this state, with the time they leave it
+     */
+    public record State(@JsonProperty("native") BigDecimal nativeAmount,
+                        BigDecimal converted,
+                        @JsonProperty("allocation_count") Integer allocationCount,
+                        List<Entry> allocations) {}
+
+    /**
+     * A single allocation of a bonding, unbonding or exit queue state.
+     *
+     * @param createdAt the time the allocation entered the state
+     * @param expires the time the allocation leaves the state
+     * @param nativeAmount the amount, in the asset of the strategy
+     * @param converted the amount, in the converted asset
+     */
+    public record Entry(@JsonProperty("created_at") Instant createdAt,
+                        Instant expires,
+                        @JsonProperty("native") BigDecimal nativeAmount,
+                        BigDecimal converted) {}
+
+    /**
+     * The reward period in progress on a strategy.
+     *
+     * @param periodStart the start of the period
+     * @param periodEnd the end of the period, when the reward is paid out
+     * @param accumulatedReward the reward accumulated so far in the period
+     * @param estimatedReward the reward expected at the end of the period
+     */
+    public record Payout(@JsonProperty("period_start") Instant periodStart,
+                         @JsonProperty("period_end") Instant periodEnd,
+                         @JsonProperty("accumulated_reward") Amount accumulatedReward,
+                         @JsonProperty("estimated_reward") Amount estimatedReward) {}
+
+    /**
+     * An amount, given both in the asset of the strategy and in the converted asset.
+     *
+     * @param nativeAmount the amount, in the asset of the strategy
+     * @param converted the amount, in the converted asset
+     */
+    public record Amount(@JsonProperty("native") BigDecimal nativeAmount,
+                         BigDecimal converted) {}
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/EarnAllocations.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/EarnAllocations.java
@@ -10,12 +10,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * The response of the {@code Earn/Allocations} endpoint, i.e. the earn allocations of the account.
  *
  * @param convertedAsset the asset the converted amounts are expressed in
+ * @param convertedAssetClass the class of that asset
  * @param totalAllocated the total amount allocated, in the converted asset
  * @param totalRewarded the total amount earned since the creation of the account, in the converted asset
  * @param nextCursor the cursor of the next page, {@code null} on the last one
  * @param items the allocations, one per strategy
  */
 public record EarnAllocations(@JsonProperty("converted_asset") String convertedAsset,
+                              @JsonProperty("converted_asset_class") AssetClass convertedAssetClass,
                               @JsonProperty("total_allocated") BigDecimal totalAllocated,
                               @JsonProperty("total_rewarded") BigDecimal totalRewarded,
                               @JsonProperty("next_cursor") String nextCursor,
@@ -26,15 +28,21 @@ public record EarnAllocations(@JsonProperty("converted_asset") String convertedA
      *
      * @param strategyId the identifier of the strategy
      * @param nativeAsset the asset allocated to the strategy
+     * @param assetClass the class of that asset
      * @param amountAllocated the allocated amount, split by state
      * @param totalRewarded the amount earned on the strategy since the creation of the account
      * @param payout the reward period in progress, {@code null} for strategies that have none
+     * @param isUtilized whether Kraken is currently putting the allocation to work
+     * @param utilizedPct the share of the allocation being put to work, as a percentage
      */
     public record Allocation(@JsonProperty("strategy_id") String strategyId,
                              @JsonProperty("native_asset") String nativeAsset,
+                             @JsonProperty("asset_class") AssetClass assetClass,
                              @JsonProperty("amount_allocated") AmountAllocated amountAllocated,
                              @JsonProperty("total_rewarded") Amount totalRewarded,
-                             Payout payout) {}
+                             Payout payout,
+                             @JsonProperty("is_utilized") boolean isUtilized,
+                             @JsonProperty("utilized_pct") BigDecimal utilizedPct) {}
 
     /**
      * The amount allocated to a strategy, split by the state the funds are in. Kraken omits the states that don't apply to the strategy.

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/EarnStrategies.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/EarnStrategies.java
@@ -1,0 +1,146 @@
+package dev.andstuff.kraken.api.endpoint.earn.response;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The response of the {@code Earn/Strategies} endpoint, i.e. a page of earn strategies.
+ *
+ * @param nextCursor the cursor of the next page, {@code null} on the last one
+ * @param items the strategies of the page
+ */
+public record EarnStrategies(@JsonProperty("next_cursor") String nextCursor,
+                             List<Strategy> items) {
+
+    /**
+     * A single earn strategy.
+     *
+     * @param id the identifier of the strategy, to be passed to the allocation endpoints
+     * @param asset the asset that can be allocated to the strategy
+     * @param lockType how the allocated funds are locked
+     * @param aprEstimate the estimated annual percentage rate, based on previous revenues, {@code null} if Kraken gives none
+     * @param allocationFee the fee taken when allocating, as a percentage
+     * @param deallocationFee the fee taken when deallocating, as a percentage
+     * @param autoCompound whether rewards are automatically allocated back to the strategy
+     * @param yieldSource where the yield comes from
+     * @param canAllocate whether the account may currently allocate to the strategy
+     * @param canDeallocate whether the account may currently deallocate from the strategy
+     * @param allocationRestrictionInfo why allocation is not possible, empty when it is
+     * @param userCap the maximum amount the account may allocate, {@code null} if uncapped
+     * @param userMinAllocation the minimum amount of a single allocation, {@code null} if there is none
+     */
+    public record Strategy(String id,
+                           String asset,
+                           @JsonProperty("lock_type") LockType lockType,
+                           @JsonProperty("apr_estimate") AprEstimate aprEstimate,
+                           @JsonProperty("allocation_fee") BigDecimal allocationFee,
+                           @JsonProperty("deallocation_fee") BigDecimal deallocationFee,
+                           @JsonProperty("auto_compound") AutoCompound autoCompound,
+                           @JsonProperty("yield_source") YieldSource yieldSource,
+                           @JsonProperty("can_allocate") boolean canAllocate,
+                           @JsonProperty("can_deallocate") boolean canDeallocate,
+                           @JsonProperty("allocation_restriction_info") List<Restriction> allocationRestrictionInfo,
+                           @JsonProperty("user_cap") BigDecimal userCap,
+                           @JsonProperty("user_min_allocation") BigDecimal userMinAllocation) {}
+
+    /**
+     * How the funds allocated to a strategy are locked. Kraken only sends the fields that apply to the lock type, the others being {@code null}.
+     *
+     * @param type the lock type
+     * @param payoutFrequency how often rewards are paid out
+     * @param bondingPeriod how long funds stay bonded before earning rewards
+     * @param bondingPeriodVariable whether the bonding period varies
+     * @param bondingRewards whether rewards are earned during the bonding period
+     * @param exitQueuePeriod how long funds stay in the exit queue before unbonding
+     * @param unbondingPeriod how long funds stay unbonding before being available again
+     * @param unbondingPeriodVariable whether the unbonding period varies
+     * @param unbondingRewards whether rewards are earned during the unbonding period
+     */
+    public record LockType(Type type,
+                           @JsonProperty("payout_frequency") Duration payoutFrequency,
+                           @JsonProperty("bonding_period") Duration bondingPeriod,
+                           @JsonProperty("bonding_period_variable") Boolean bondingPeriodVariable,
+                           @JsonProperty("bonding_rewards") Boolean bondingRewards,
+                           @JsonProperty("exit_queue_period") Duration exitQueuePeriod,
+                           @JsonProperty("unbonding_period") Duration unbondingPeriod,
+                           @JsonProperty("unbonding_period_variable") Boolean unbondingPeriodVariable,
+                           @JsonProperty("unbonding_rewards") Boolean unbondingRewards) {
+
+        /**
+         * The kind of lock applied to allocated funds.
+         */
+        public enum Type {
+            FLEX,
+            BONDED,
+            TIMED,
+            INSTANT,
+
+            @JsonEnumDefaultValue
+            UNKNOWN
+        }
+    }
+
+    /**
+     * The estimated annual percentage rate of a strategy.
+     *
+     * @param low the lower bound of the estimate
+     * @param high the upper bound of the estimate
+     */
+    public record AprEstimate(BigDecimal low,
+                              BigDecimal high) {}
+
+    /**
+     * Whether rewards are allocated back to the strategy.
+     *
+     * @param type whether auto compounding is disabled, enforced or left to the account
+     * @param enabledByDefault whether an optional auto compounding is on unless the account says otherwise, {@code null} when it is not optional
+     */
+    public record AutoCompound(Type type,
+                               @JsonProperty("default") Boolean enabledByDefault) {
+
+        /**
+         * How auto compounding applies to a strategy.
+         */
+        public enum Type {
+            DISABLED,
+            ENABLED,
+            OPTIONAL,
+
+            @JsonEnumDefaultValue
+            UNKNOWN
+        }
+    }
+
+    /**
+     * Where the yield of a strategy comes from.
+     *
+     * @param type the source of the yield
+     */
+    public record YieldSource(Type type) {
+
+        /**
+         * The kind of source generating the yield.
+         */
+        public enum Type {
+            STAKING,
+            OFF_CHAIN,
+
+            @JsonEnumDefaultValue
+            UNKNOWN
+        }
+    }
+
+    /**
+     * Why an account may not allocate to a strategy.
+     */
+    public enum Restriction {
+        TIER,
+
+        @JsonEnumDefaultValue
+        UNKNOWN
+    }
+}

--- a/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/EarnStrategies.java
+++ b/library/src/main/java/dev/andstuff/kraken/api/endpoint/earn/response/EarnStrategies.java
@@ -21,6 +21,7 @@ public record EarnStrategies(@JsonProperty("next_cursor") String nextCursor,
      *
      * @param id the identifier of the strategy, to be passed to the allocation endpoints
      * @param asset the asset that can be allocated to the strategy
+     * @param assetClass the class of that asset
      * @param lockType how the allocated funds are locked
      * @param aprEstimate the estimated annual percentage rate, based on previous revenues, {@code null} if Kraken gives none
      * @param allocationFee the fee taken when allocating, as a percentage
@@ -35,6 +36,7 @@ public record EarnStrategies(@JsonProperty("next_cursor") String nextCursor,
      */
     public record Strategy(String id,
                            String asset,
+                           @JsonProperty("asset_class") AssetClass assetClass,
                            @JsonProperty("lock_type") LockType lockType,
                            @JsonProperty("apr_estimate") AprEstimate aprEstimate,
                            @JsonProperty("allocation_fee") BigDecimal allocationFee,
@@ -52,6 +54,7 @@ public record EarnStrategies(@JsonProperty("next_cursor") String nextCursor,
      *
      * @param type the lock type
      * @param payoutFrequency how often rewards are paid out
+     * @param durationMonths how long the funds stay locked, on a timed strategy
      * @param bondingPeriod how long funds stay bonded before earning rewards
      * @param bondingPeriodVariable whether the bonding period varies
      * @param bondingRewards whether rewards are earned during the bonding period
@@ -62,6 +65,7 @@ public record EarnStrategies(@JsonProperty("next_cursor") String nextCursor,
      */
     public record LockType(Type type,
                            @JsonProperty("payout_frequency") Duration payoutFrequency,
+                           @JsonProperty("duration_months") Integer durationMonths,
                            @JsonProperty("bonding_period") Duration bondingPeriod,
                            @JsonProperty("bonding_period_variable") Boolean bondingPeriodVariable,
                            @JsonProperty("bonding_rewards") Boolean bondingRewards,
@@ -128,6 +132,8 @@ public record EarnStrategies(@JsonProperty("next_cursor") String nextCursor,
         public enum Type {
             STAKING,
             OFF_CHAIN,
+            OPT_IN_REWARDS,
+            BASE_REWARDS,
 
             @JsonEnumDefaultValue
             UNKNOWN


### PR DESCRIPTION
Types the six Earn endpoints of the Kraken Spot REST API, part of the coverage effort tracked in #82.

## What's added

- `endpoint/earn/` — new domain package, alongside `market/`, `account/`, `subaccount/` and `transparency/`
- `EarnStrategiesEndpoint` → `PrivateEndpoint<EarnStrategies>`, params `EarnStrategiesParams` (builder: `ascending`, `asset`, `cursor`, `limit`, `lockTypes`)
- `EarnAllocationsEndpoint` → `PrivateEndpoint<EarnAllocations>`, params `EarnAllocationsParams` (builder: `ascending`, `convertedAsset`, `hideZeroAllocations`)
- `EarnAllocateEndpoint` and `EarnDeallocateEndpoint` → `PrivateEndpoint<Boolean>`, both taking `EarnAllocationParams.of(strategyId, amount)`
- `EarnAllocateStatusEndpoint` and `EarnDeallocateStatusEndpoint` → `PrivateEndpoint<AllocationStatus>`, both taking `EarnStatusParams.of(strategyId)`
- `EarnStrategies` response record — `nextCursor` and a list of `Strategy` records, with nested `LockType`, `AprEstimate`, `AutoCompound` and `YieldSource` records and a `Restriction` enum
- `EarnAllocations` response record — `convertedAsset`, `totalAllocated`, `totalRewarded`, `nextCursor` and a list of `Allocation` records, with nested `AmountAllocated`, `State`, `Entry`, `Payout` and `Amount` records
- `AllocationStatus` response record — the single `pending` flag both status endpoints return
- `LockType` params enum — the `flex` / `bonded` / `timed` / `instant` filter of `Earn/Strategies`
- `KrakenAPI.earnStrategies()`, `earnStrategies(params)`, `earnAllocations()`, `earnAllocations(params)`, `earnAllocate(params)`, `earnDeallocate(params)`, `earnAllocateStatus(strategyId)` and `earnDeallocateStatus(strategyId)`, all routed through `query(PrivateEndpoint<T>)`
- `AGENTS.md`: `earn/` added to the domain package list

## Notes

Allocate and Deallocate take the same two parameters, and the two status endpoints take the same one, so each pair shares a params class instead of getting four near-identical ones — the way `RemoveReportParams` already serves both `deleteReport` and `cancelReport`.

`lock_type` is the only array parameter of the six endpoints, and `PostParams` models a request body as `Map<String, String>`, so it is sent comma-joined: `lock_type=bonded,instant`. That matches how the library already encodes list parameters Kraken documents as arrays, e.g. the asset list of `Ledgers`, but it is the one wire detail here that couldn't be verified against the live API without an Earn-enabled key. If Kraken turns out to want repeated `lock_type[]=` keys, `PostParams` needs a multi-value key before this parameter can be fixed.

`Duration` is used for the lock periods (`payout_frequency`, `bonding_period`, `exit_queue_period`, `unbonding_period`), which Kraken sends as a number of seconds. `LockType` carries the union of the fields of the four lock variants rather than a Jackson polymorphic hierarchy: Kraken only sends the fields that apply, the rest deserialize to `null`, and an unknown future variant still parses.

The `timed` lock variant is in Kraken's enum but has no schema in their docs, so it is an enum constant with no dedicated fields. Fee fields are typed `BigDecimal`, Kraken sending them sometimes as strings and sometimes as numbers.

Response records use `nativeAmount` with `@JsonProperty("native")` throughout, `native` being a Java keyword.

## Verification

`mvn clean package` passes, and `javadoc:jar` adds no warnings beyond the `-missing` ones the project already tolerates on obvious enum constants.

The endpoints are private and need an Earn-enabled API key, so they were exercised offline with a throwaway class (not committed), through the project's Jackson configuration and the real `PostParams` / `PrivateEndpoint` code paths:

- `Earn/Strategies` and `Earn/Allocations` sample payloads deserialize into fully populated records, including `payout_frequency: 604800` → `PT168H`, `bonding_period: 1209600` → `PT336H`, `"auto_compound": {"type": "optional", "default": true}`, `"yield_source": {"type": "off_chain"}` → `OFF_CHAIN`, and the nested `bonding` / `exit_queue` / `unbonding` states with their per-allocation entries.
- Unknown enum values (`"type": "brand_new"`, `"allocation_restriction_info": ["moon_phase"]`) fall back to `UNKNOWN`, and unknown properties are ignored, as the mapper is configured to.
- Request bodies and URLs are what Kraken expects: `limit=10&ascending=true&asset=ETH&lock_type=bonded%2Cinstant&nonce=1755640000000` on `https://api.kraken.com/0/private/Earn/Strategies`, and `amount=0.00000010&strategy_id=ESRFUO3-Q62XD-WIOIL7&nonce=…` on `Earn/Allocate`. The slash in the endpoint path lands in the signed URL path unchanged, which is what the `API-Sign` computation needs.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
